### PR TITLE
fix(task-mapper): correct userId mapping in TaskMapper

### DIFF
--- a/src/main/java/ptithcm/itmc/taskracer/service/mapper/task/TaskMapper.java
+++ b/src/main/java/ptithcm/itmc/taskracer/service/mapper/task/TaskMapper.java
@@ -28,7 +28,7 @@ public interface TaskMapper {
 
     default Set<UUID> toListUserId(Set<JpaTaskAssignees> taskAssignees) {
         return taskAssignees.stream()
-                .map(data -> data.getId())
+                .map(data -> data.getUserId())
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
The TaskMapper was incorrectly mapping task assignee ids instead of user ids.

- Correct the mapping to retrieve user ids.

This ensures that the correct user ids are associated with tasks.